### PR TITLE
Fetch accounts is complex

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import Web3Gate from "./components/web3Gate"
-import { inject, observer } from "mobx-react"
 import "./assets/less/index"
 
 import AppContent from "./components/appComponents/appContent"

--- a/src/components/web3Gate.js
+++ b/src/components/web3Gate.js
@@ -90,8 +90,11 @@ class Web3Gate extends Component {
   instantiateWeb3() {
     const { augesco } = this.props;
     this.fetchAccounts();
+    augesco.updateAccountStatus()
 
     augesco.web3.currentProvider.publicConfigStore.on("update", () => {
+      augesco.updateAccountStatus()
+
       this.fetchAccounts();
     });
 

--- a/src/components/web3Gate.js
+++ b/src/components/web3Gate.js
@@ -88,14 +88,14 @@ class Web3Gate extends Component {
   }
 
   instantiateWeb3() {
-    const { augesco } = this.props;
-    this.fetchAccounts();
-    augesco.updateAccountStatus()
+    const { augesco, event_providers } = this.props;
+    //this.fetchAccounts();
+    augesco.updateAccountStatus(event_providers)
 
     augesco.web3.currentProvider.publicConfigStore.on("update", () => {
-      augesco.updateAccountStatus()
+      augesco.updateAccountStatus(event_providers)
 
-      this.fetchAccounts();
+      //this.fetchAccounts();
     });
 
     window.addEventListener("offline", function(e) {

--- a/src/components/web3Gate.js
+++ b/src/components/web3Gate.js
@@ -29,7 +29,7 @@ class Web3Gate extends Component {
     const { augesco } = this.props;
 
     if (
-      augesco.status !== web3Context.WEB3_CONTRACT_ERR &&
+      augesco.status !== web3Context.WEB3_CONTRACT_ERR ||
       augesco.status !== web3Context.WEB3_NET_ERR
     ) {
       augesco.web3.eth.getAccounts((err, accounts) => {
@@ -105,7 +105,6 @@ class Web3Gate extends Component {
   }
 
   componentWillMount() {
-    console.log(this.props);
     const online = navigator.onLine;
     if (online) {
       getWeb3

--- a/src/components/web3Gate.js
+++ b/src/components/web3Gate.js
@@ -8,7 +8,6 @@ import Web3NotInstalled from "./web3Components/web3NotInstalled";
 import Web3NoNetwork from "./web3Components/web3NoNetwork";
 import Web3NoContract from "./web3Components/web3NoContract";
 import ContractGate from "./contractComponents/contractGate";
-import Web3 from "web3";
 
 @inject("augesco")
 @observer
@@ -20,82 +19,12 @@ class Web3Gate extends Component {
     };
   }
 
-  hasProviders() {
-    const { augesco, event_providers } = this.props;
-    return event_providers[augesco.netName];
-  }
-
-  fetchAccounts() {
-    const { augesco } = this.props;
-
-    if (
-      augesco.status !== web3Context.WEB3_CONTRACT_ERR ||
-      augesco.status !== web3Context.WEB3_NET_ERR
-    ) {
-      augesco.web3.eth.getAccounts((err, accounts) => {
-        if (err) {
-          console.log(err);
-          augesco.updateStatus(web3Context.WEB3_LOAD_ERR);
-        } else {
-          if (accounts.length === 0) {
-            augesco.updateStatus(web3Context.WEB3_LOCKED);
-          } else {
-            augesco.determineNetwork().then(network => {
-              if (network !== undefined) {
-                augesco.updateNetwork(network);
-
-                const provider = this.hasProviders();
-
-                if (provider !== undefined) {
-                  if (augesco.web3_ws === undefined) {
-                    const web3_ws = new Web3(
-                      new Web3.providers.WebsocketProvider(provider)
-                    );
-                    augesco.setWeb3Websocket(web3_ws);
-                  }
-                } else {
-                  augesco.updateStatus(web3Context.WEB3_LOADING);
-                }
-
-                if (accounts[0] !== augesco.account) {
-                  augesco.setAccount(accounts[0]);
-                }
-                this.fetchBalance();
-                augesco.updateStatus(web3Context.WEB3_LOADED);
-              } else {
-                augesco.updateStatus(web3Context.WEB3_NET_ERR);
-              }
-            });
-          }
-        }
-      });
-    }
-  }
-
-  fetchBalance() {
-    const { augesco } = this.props;
-    if (augesco.status === web3Context.WEB3_LOADED) {
-      augesco.web3.eth.getBalance(augesco.account, (err, _balance) => {
-        if (err) {
-          console.log(err);
-        } else {
-          if (_balance !== augesco.balance) {
-            augesco.updateBalance(_balance);
-          }
-        }
-      });
-    }
-  }
-
   instantiateWeb3() {
     const { augesco, event_providers } = this.props;
-    //this.fetchAccounts();
     augesco.updateAccountStatus(event_providers)
 
     augesco.web3.currentProvider.publicConfigStore.on("update", () => {
       augesco.updateAccountStatus(event_providers)
-
-      //this.fetchAccounts();
     });
 
     window.addEventListener("offline", function(e) {

--- a/src/models/aguescoModel.js
+++ b/src/models/aguescoModel.js
@@ -1,10 +1,9 @@
 import { types, flow } from "mobx-state-tree";
-import { web3Context } from "../constants";
-import { BigNumber } from 'bignumber.js';
-import getWeb3Network from "../utils/getWeb3Network"
-import { contractInstance } from "./instanceContract"
-import { transactionInstance } from "./instanceTx"
-import { txStatus } from "../constants"
+import { BigNumber } from "bignumber.js";
+import getWeb3Network from "../utils/getWeb3Network";
+import { contractInstance } from "./instanceContract";
+import { transactionInstance } from "./instanceTx";
+import { txStatus, web3Context } from "../constants";
 
 const web3Contexts = [
   web3Context.WEB3_LOAD_ERR,
@@ -17,6 +16,17 @@ const web3Contexts = [
 
 let ptx = null;
 let nbh = null;
+
+const checkError = context => {
+  if (
+    context === web3Context.WEB3_CONTRACT_ERR ||
+    context === web3Context.WEB3_NET_ERR
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+};
 
 export const AugescoStore = types
   .model({
@@ -33,7 +43,16 @@ export const AugescoStore = types
     info: false
   })
   .actions(self => ({
-    add(_id, _abi, _txHash, _address, _contract, _methods, _eventContract, _events) {
+    add(
+      _id,
+      _abi,
+      _txHash,
+      _address,
+      _contract,
+      _methods,
+      _eventContract,
+      _events
+    ) {
       self.contracts.set(_id, {
         name: _id,
         abi: _abi,
@@ -43,13 +62,13 @@ export const AugescoStore = types
         methods: _methods,
         eventContract: _eventContract,
         events: _events
-      })
+      });
     },
     toggleLoaded() {
-      self.loaded = !self.loaded
+      self.loaded = !self.loaded;
     },
     toggleInfo() {
-      self.info = !self.info
+      self.info = !self.info;
     },
     setWeb3(web3) {
       self.web3 = web3;
@@ -73,71 +92,6 @@ export const AugescoStore = types
     updateNetwork(network) {
       self.network = network;
     },
-    use(_id) {
-      if (self.loaded && self.contracts.has(_id)) {
-        return self.contracts.get(_id)
-      } else {
-        return {}
-      }
-    },
-    getMethod(_id, _method) {
-      if (self.loaded && self.contracts.has(_id)) {
-        return self.use(_id).getMethod(_method)
-      } else {
-        return {}
-      }
-    },
-    createTx(_id) {
-      self.transactions.set(_id, {
-        hash: _id,
-        receipt: {},
-        status: txStatus.PENDING
-      })
-    },
-    useTx(_id) {
-      if (self.loaded && self.transactions.has(_id)) {
-        return self.transactions.get(_id)
-      } else {
-        return {}
-      }
-    },
-    startTx(_id) {
-      self.useTx(_id).txStart()
-    },
-    call: flow(function* call(_id, _method, _args) {
-      if (self.loaded && self.contracts.has(_id)) {
-        try {
-          return yield self.getMethod(_id, _method)["func"](..._args).call()
-        } catch (error) {
-          console.error(error)
-        }
-      } else {
-        return undefined
-      }
-    }),
-    exec: flow(function* exec(_id, _method, _args, _params) {
-      if (self.loaded && self.contracts.has(_id)) {
-        try {
-          yield self.getMethod(_id, _method)["func"](..._args)
-            .send(_params)
-            .on('transactionHash', function (hash) {
-              self.createTx(hash)
-              self.startTx(hash)
-            })
-        } catch (error) {
-          console.error(error)
-        }
-      } else {
-        console.error("Not ready")
-      }
-    }),
-    listen(_id, _event, _options, _cb) {
-      if (self.loaded && self.contracts.has(_id)) {
-        self.use(_id).events[_event](..._options, _cb)
-      } else {
-        console.error("Not ready")
-      }
-    },
     determineNetwork: flow(function* determineNetwork() {
       try {
         return yield self.web3.eth.net.getId();
@@ -145,6 +99,79 @@ export const AugescoStore = types
         self.updateStatus(web3Context.WEB3_NET_ERR);
       }
     }),
+    updateAccountStatus() {
+
+    },
+    use(_id) {
+      if (self.loaded && self.contracts.has(_id)) {
+        return self.contracts.get(_id);
+      } else {
+        return {};
+      }
+    },
+    getMethod(_id, _method) {
+      if (self.loaded && self.contracts.has(_id)) {
+        return self.use(_id).getMethod(_method);
+      } else {
+        return {};
+      }
+    },
+    createTx(_id) {
+      self.transactions.set(_id, {
+        hash: _id,
+        receipt: {},
+        status: txStatus.PENDING
+      });
+    },
+    useTx(_id) {
+      if (self.loaded && self.transactions.has(_id)) {
+        return self.transactions.get(_id);
+      } else {
+        return {};
+      }
+    },
+    startTx(_id) {
+      self.useTx(_id).txStart();
+    },
+    call: flow(function* call(_id, _method, _args) {
+      if (self.loaded && self.contracts.has(_id)) {
+        try {
+          return yield self
+            .getMethod(_id, _method)
+            ["func"](..._args)
+            .call();
+        } catch (error) {
+          console.error(error);
+        }
+      } else {
+        return undefined;
+      }
+    }),
+    exec: flow(function* exec(_id, _method, _args, _params) {
+      if (self.loaded && self.contracts.has(_id)) {
+        try {
+          yield self
+            .getMethod(_id, _method)
+            ["func"](..._args)
+            .send(_params)
+            .on("transactionHash", function(hash) {
+              self.createTx(hash);
+              self.startTx(hash);
+            });
+        } catch (error) {
+          console.error(error);
+        }
+      } else {
+        console.error("Not ready");
+      }
+    }),
+    listen(_id, _event, _options, _cb) {
+      if (self.loaded && self.contracts.has(_id)) {
+        self.use(_id).events[_event](..._options, _cb);
+      } else {
+        console.error("Not ready");
+      }
+    },
     startPendingTxs() {
       if (self.status === web3Context.WEB3_LOADED) {
         ptx = self.web3_ws.eth.subscribe(
@@ -199,12 +226,12 @@ export const AugescoStore = types
       return getWeb3Network(self.network);
     },
     get keys() {
-      return Array.from(self.contracts.keys())
+      return Array.from(self.contracts.keys());
     },
     get values() {
-      return Array.from(self.contracts.values())
+      return Array.from(self.contracts.values());
     },
     get json() {
-      return self.contracts.toJSON()
+      return self.contracts.toJSON();
     }
   }));

--- a/src/models/aguescoModel.js
+++ b/src/models/aguescoModel.js
@@ -107,16 +107,31 @@ export const AugescoStore = types
         self.updateStatus(web3Context.WEB3_LOAD_ERR)
       }
     }),
-    updateAccountStatus: flow(function* updateAccountStatus() {
+    updateAccountStatus: flow(function* updateAccountStatus(providers) {
       try {
         if(getWeb3Context(self.status)) {
+
           const newAccount = yield self.determineAccount()
-          console.log(newAccount)
-          if(self.status !== web3Context.WEB3_LOAD_ERR) {
+          if(newAccount.length === 0) {
+            self.updateStatus(web3Context.WEB3_LOCKED)
+            throw new Error('No account found')
+          } 
+            
+          const newNetwork = yield self.determineNetwork()
+          if(newNetwork === undefined) {
+            self.updateStatus(web3Context.WEB3_NET_ERR)
+            throw new Error('No network found')
+          }
+          self.updateNetwork(newNetwork)
+
+          const provider = providers[self.netName]
+          if(provider === undefined) {
+            self.updateStatus(web3Context.WEB3_LOADING)
+            throw new Error('No provider given')
           }
         }
       } catch (error) {
-        console.err(error)
+        console.error(error)
       }
     }),
     use(_id) {


### PR DESCRIPTION
Solves #9 
- user account status is now determined through the `augesco.updateAccountStatus()` prop.
- added `determineAccount()` to model. Async call to web3 to determine current account.
- added `determineBalance()` to model. Async call to web3 to determine account balance.
- replaced all instances of `fetchAccounts()` with `augesco.updateAccountStatus()` in web3Gate.js
- auto-formatted model with prettier.js